### PR TITLE
Feature/assume mandatory

### DIFF
--- a/const_typed_builder_derive/src/info/field_info.rs
+++ b/const_typed_builder_derive/src/info/field_info.rs
@@ -5,7 +5,7 @@ use proc_macro2::Span;
 use syn::{ExprPath, Token};
 
 use crate::{
-    symbol::{BUILDER, GROUP, MANDATORY, PROPAGATE, OPTIONAL},
+    symbol::{BUILDER, GROUP, MANDATORY, OPTIONAL, PROPAGATE},
     util::{inner_type, is_option},
 };
 

--- a/const_typed_builder_derive/src/info/field_info.rs
+++ b/const_typed_builder_derive/src/info/field_info.rs
@@ -5,7 +5,7 @@ use proc_macro2::Span;
 use syn::{ExprPath, Token};
 
 use crate::{
-    symbol::{BUILDER, GROUP, MANDATORY, PROPAGATE},
+    symbol::{BUILDER, GROUP, MANDATORY, PROPAGATE, OPTIONAL},
     util::{inner_type, is_option},
 };
 
@@ -283,10 +283,9 @@ impl FieldSettings {
                 return Ok(());
             }
         }
-        if let syn::Meta::List(list) = &attr.meta {
-            if list.tokens.is_empty() {
-                return Ok(());
-            }
+        let list = attr.meta.require_list()?;
+        if list.tokens.is_empty() {
+            return Ok(());
         }
 
         attr.parse_nested_meta(|meta| {
@@ -302,6 +301,20 @@ impl FieldSettings {
                     }
                 } else {
                     self.mandatory = true;
+                }
+            }
+            if meta.path == OPTIONAL {
+                if meta.input.peek(Token![=]) {
+                    let expr: syn::Expr = meta.value()?.parse()?;
+                    if let syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Bool(syn::LitBool { value, .. }),
+                        ..
+                    }) = expr
+                    {
+                        self.mandatory = !value;
+                    }
+                } else {
+                    self.mandatory = false;
                 }
             }
             if meta.path == GROUP {

--- a/const_typed_builder_derive/src/info/struct_info.rs
+++ b/const_typed_builder_derive/src/info/struct_info.rs
@@ -5,7 +5,7 @@ use super::group_info::{GroupInfo, GroupType};
 use quote::format_ident;
 use syn::Token;
 
-use crate::symbol::{AT_LEAST, AT_MOST, EXACT, GROUP, SINGLE, BUILDER, ASSUME_MANDATORY};
+use crate::symbol::{ASSUME_MANDATORY, AT_LEAST, AT_MOST, BUILDER, EXACT, GROUP, SINGLE};
 
 type FieldInfos<'a> = Vec<FieldInfo<'a>>;
 
@@ -164,7 +164,7 @@ impl StructSettings {
         }
     }
 
-    fn handle_builder_attribute(&mut self, attr: &syn::Attribute)  -> syn::Result<()> {
+    fn handle_builder_attribute(&mut self, attr: &syn::Attribute) -> syn::Result<()> {
         let list = attr.meta.require_list()?;
         if list.tokens.is_empty() {
             return Ok(());


### PR DESCRIPTION
Add a feature to assume each `Option` field as mandatory, using `#[builder(assume_mandatory)]`. An actual optional value can be marked with `#[builder(optional)]`