### PR TITLE
Feature/assume mandatory

### DIFF
--- a/const_typed_builder_derive/src/info/field_info.rs
+++ b/const_typed_builder_derive/src/info/field_info.rs
@@ -5,7 +5,7 @@ use proc_macro2::Span;
 use syn::{ExprPath, Token};
 
 use crate::{
-    symbol::{BUILDER, GROUP, MANDATORY, PROPAGATE, OPTIONAL},
+    symbol::{BUILDER, GROUP, MANDATORY, OPTIONAL, PROPAGATE},
     util::{inner_type, is_option},
 };
 

--- a/const_typed_builder_derive/src/info/field_info.rs
+++ b/const_typed_builder_derive/src/info/field_info.rs
@@ -5,7 +5,7 @@ use proc_macro2::Span;
 use syn::{ExprPath, Token};
 
 use crate::{
-    symbol::{BUILDER, GROUP, MANDATORY, PROPAGATE},
+    symbol::{BUILDER, GROUP, MANDATORY, PROPAGATE, OPTIONAL},
     util::{inner_type, is_option},
 };
 
@@ -283,10 +283,9 @@ impl FieldSettings {
                 return Ok(());
             }
         }
-        if let syn::Meta::List(list) = &attr.meta {
-            if list.tokens.is_empty() {
-                return Ok(());
-            }
+        let list = attr.meta.require_list()?;
+        if list.tokens.is_empty() {
+            return Ok(());
         }
 
         attr.parse_nested_meta(|meta| {
@@ -302,6 +301,20 @@ impl FieldSettings {
                     }
                 } else {
                     self.mandatory = true;
+                }
+            }
+            if meta.path == OPTIONAL {
+                if meta.input.peek(Token![=]) {
+                    let expr: syn::Expr = meta.value()?.parse()?;
+                    if let syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Bool(syn::LitBool { value, .. }),
+                        ..
+                    }) = expr
+                    {
+                        self.mandatory = !value;
+                    }
+                } else {
+                    self.mandatory = false;
                 }
             }
             if meta.path == GROUP {

--- a/const_typed_builder_derive/src/info/struct_info.rs
+++ b/const_typed_builder_derive/src/info/struct_info.rs
@@ -5,7 +5,7 @@ use super::group_info::{GroupInfo, GroupType};
 use quote::format_ident;
 use syn::Token;
 
-use crate::symbol::{AT_LEAST, AT_MOST, EXACT, GROUP, SINGLE, BUILDER, ASSUME_MANDATORY};
+use crate::symbol::{ASSUME_MANDATORY, AT_LEAST, AT_MOST, BUILDER, EXACT, GROUP, SINGLE};
 
 type FieldInfos<'a> = Vec<FieldInfo<'a>>;
 
@@ -164,7 +164,7 @@ impl StructSettings {
         }
     }
 
-    fn handle_builder_attribute(&mut self, attr: &syn::Attribute)  -> syn::Result<()> {
+    fn handle_builder_attribute(&mut self, attr: &syn::Attribute) -> syn::Result<()> {
         let list = attr.meta.require_list()?;
         if list.tokens.is_empty() {
             return Ok(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,6 +423,43 @@ mod test {
     }
 
     #[test]
+    fn assume_mandatory() {
+        #[derive(Debug, Default, PartialEq, Eq, Builder)]
+        #[builder(assume_mandatory)]
+        pub struct Foo {
+            bar: Option<String>,
+        }
+
+        let expected = Foo {
+            bar: Some("Hello world!".to_string()),
+        };
+        let foo = Foo::builder().bar("Hello world!".to_string()).build();
+        assert_eq!(expected, foo);
+
+    }
+
+    #[test]
+    fn assume_mandatory_explicit_optional() {
+        #[derive(Debug, Default, PartialEq, Eq, Builder)]
+        #[builder(assume_mandatory)]
+        pub struct Foo {
+            bar: Option<String>,
+            baz: Option<String>,
+            #[builder(optional)]
+            quz: Option<String>,
+        }
+
+        let expected = Foo {
+            bar: Some("Hello world!".to_string()),
+            baz: Some("Hello world!".to_string()),
+            quz: None,
+        };
+        let foo = Foo::builder().bar("Hello world!".to_string()).baz("Hello world!".to_string()).build();
+        assert_eq!(expected, foo);
+
+    }
+
+    #[test]
     fn group() {
         #[derive(Debug, Default, PartialEq, Eq, Builder)]
         #[group(baz = single)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,21 @@
 ///     .bar("Hello".to_string())
 ///     .build();
 /// ```
+/// 
+/// Or you can assume everything is mandatory altogether with `assume_mandatory` and `optional`.
+/// 
+/// ```
+/// # use const_typed_builder::Builder;
+/// #[derive(Debug, Builder)]
+/// #[builder(assume_mandatory)]
+/// pub struct Foo {
+///     bar: Option<String>,
+///     baz: Option<String>,
+///     #[builder(optional)]
+///     quz: Option<String>,
+/// }
+/// let foo = Foo::builder().bar("Hello world!".to_string()).baz("Hello world!".to_string()).build();
+/// ```
 ///
 /// ## 3. Grouping Fields
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,9 +76,9 @@
 ///     .bar("Hello".to_string())
 ///     .build();
 /// ```
-/// 
+///
 /// Or you can assume everything is mandatory altogether with `assume_mandatory` and `optional`.
-/// 
+///
 /// ```
 /// # use const_typed_builder::Builder;
 /// #[derive(Debug, Builder)]
@@ -450,7 +450,6 @@ mod test {
         };
         let foo = Foo::builder().bar("Hello world!".to_string()).build();
         assert_eq!(expected, foo);
-
     }
 
     #[test]
@@ -469,9 +468,11 @@ mod test {
             baz: Some("Hello world!".to_string()),
             quz: None,
         };
-        let foo = Foo::builder().bar("Hello world!".to_string()).baz("Hello world!".to_string()).build();
+        let foo = Foo::builder()
+            .bar("Hello world!".to_string())
+            .baz("Hello world!".to_string())
+            .build();
         assert_eq!(expected, foo);
-
     }
 
     #[test]


### PR DESCRIPTION
Add a feature to assume each Option field as mandatory, using #[builder(assume_mandatory)]. An actual optional value can be marked with #[builder(optional)]

Merged into master incomplete by accident