### PR TITLE
Feature/remove derive debug from foobuilder and foodata structs

### DIFF
--- a/const_typed_builder_derive/src/generator/builder_generator.rs
+++ b/const_typed_builder_derive/src/generator/builder_generator.rs
@@ -93,7 +93,6 @@ impl<'a> BuilderGenerator<'a> {
         let vis = self.target_vis;
 
         quote!(
-            #[derive(Debug)]
             #vis struct #builder_name #impl_generics #where_clause {
                 #data_field: #data_name #type_generics
             }

--- a/const_typed_builder_derive/src/generator/data_generator.rs
+++ b/const_typed_builder_derive/src/generator/data_generator.rs
@@ -94,7 +94,6 @@ impl<'a> DataGenerator<'a> {
             self.generics_gen.target_generics().split_for_impl();
 
         let tokens = quote!(
-            #[derive(Debug)]
             pub struct #data_name #impl_generics #where_clause{
                 #(#fields),*
             }

--- a/const_typed_builder_test/src/lib.rs
+++ b/const_typed_builder_test/src/lib.rs
@@ -655,4 +655,14 @@ mod test {
             .build();
         assert_eq!(expected, foo);
     }
+
+    #[test]
+    fn no_other_derive_necessary() {
+        #[derive(Builder)]
+        pub struct Foo {
+            bar: String,
+        }
+        let foo = Foo::builder().bar("Hello world!".to_string()).build();
+        assert_eq!(foo.bar, "Hello world!");
+    }
 }


### PR DESCRIPTION
Remove Debug derive from Data and Builder structs.

If necessary I can create a feature that includes it if requested by the user